### PR TITLE
fix: Keep comments when sorting yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "dependencies": {
     "@types/js-yaml": "^4.0.5",
     "@types/jsonabc": "^2.3.1",
-    "js-yaml": "^4.1.0",
     "json5": "^2.2.1",
-    "jsonabc": "^2.3.1"
+    "jsonabc": "^2.3.1",
+    "yaml": "^2.1.3"
   },
   "description": "Sort JSON, YAML and plain text files by using a keyboard shortcut.",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     ]
   },
   "dependencies": {
-    "@types/js-yaml": "^4.0.5",
     "@types/jsonabc": "^2.3.1",
     "json5": "^2.2.1",
     "jsonabc": "^2.3.1",

--- a/src/sort/sortYAML.ts
+++ b/src/sort/sortYAML.ts
@@ -1,7 +1,7 @@
 import {Document, ParsedNode, parseDocument, YAMLMap, YAMLSeq} from 'yaml';
 import type {SortFunction} from './SortFunction';
 
-function sortDeep(node: ParsedNode | null) {
+function sortDeep(node: ParsedNode | null): void {
   if (node instanceof YAMLMap) {
     node.items.sort((itemA, itemB) => (itemA.key < itemB.key ? -1 : itemA.key > itemB.key ? 1 : 0));
     node.items.forEach(item => sortDeep(item.value));

--- a/src/sort/sortYAML.ts
+++ b/src/sort/sortYAML.ts
@@ -1,4 +1,4 @@
-import {Document, ParsedNode, parseDocument, YAMLMap, YAMLSeq} from 'yaml';
+import {ParsedNode, parseDocument, YAMLMap, YAMLSeq} from 'yaml';
 import type {SortFunction} from './SortFunction';
 
 function sortDeep(node: ParsedNode | null): void {
@@ -10,18 +10,13 @@ function sortDeep(node: ParsedNode | null): void {
   }
 }
 
-function stableStringify(doc: Document.Parsed<ParsedNode>): string {
-  sortDeep(doc.contents);
-  return doc.toString();
-}
-
 export const sortYAML: SortFunction = function (text: string) {
   try {
     const document = parseDocument(text);
-    const sorted = stableStringify(document);
+    sortDeep(document.contents);
 
     return {
-      payload: sorted,
+      payload: document.toString(),
       type: 'success',
     };
   } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,11 +131,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/js-yaml@^4.0.5":
-  version "4.0.5"
-  resolved "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz"
-  integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
-
 "@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,6 +2171,11 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.3.tgz#9b3a4c8aff9821b696275c79a8bee8399d945207"
+  integrity sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==
+
 yargs-parser@20.2.4:
   version "20.2.4"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"


### PR DESCRIPTION
This PR will use [eemeli's yaml package](https://github.com/eemeli/yaml) to parse yaml files and @murrayju's sorting algorithm from https://github.com/eemeli/yaml/issues/44#issuecomment-571696527 to fix #1.