### PR TITLE
fix: preserve comments when sorting JSON/JSONC (#12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@types/jsonabc": "^2.3.3",
+    "comment-json": "4.2.5",
     "json5": "^2.2.3",
     "jsonabc": "^2.3.1",
     "yaml": "^2.9.0"

--- a/src/sort/sortJSON.test.ts
+++ b/src/sort/sortJSON.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import {sortJSON} from './sortJSON';
+
+function readFixture(name: string): string {
+  return fs.readFileSync(path.join(__dirname, '../test/fixtures', name), 'utf-8');
+}
+
+describe('sortJSON', () => {
+  it('sorts object keys', () => {
+    const actual = sortJSON('{"xyz": "xyz", "abc": "abc"}');
+    assert(actual.type === 'success');
+    expect(actual.payload).toBe(`{
+  "abc": "abc",
+  "xyz": "xyz"
+}`);
+  });
+
+  it('preserves line comments and keeps them with their property', () => {
+    const actual = sortJSON(readFixture('line-comments.json5'));
+    assert(actual.type === 'success');
+    expect(actual.payload).toBe(`{
+  // ABC
+  "abc": "abc",
+  // XYZ
+  "xyz": "xyz"
+}`);
+  });
+
+  it('preserves block comments and keeps them with their property', () => {
+    const actual = sortJSON(readFixture('block-comments.json5'));
+    assert(actual.type === 'success');
+    expect(actual.payload).toBe(`{
+  /* ABC */
+  "abc": "abc",
+  /* XYZ */
+  "xyz": "xyz"
+}`);
+  });
+
+  it('preserves comments inside nested objects', () => {
+    const actual = sortJSON(readFixture('nested-comments.json5'));
+    assert(actual.type === 'success');
+    expect(actual.payload).toBe(`{
+  "active": true,
+  // root note
+  "server": {
+    "host": "localhost",
+    // port to bind
+    "port": 8080
+  }
+}`);
+  });
+
+  it('reports an error for invalid input', () => {
+    const actual = sortJSON('this is not json');
+    expect(actual.type).toBe('error');
+  });
+});

--- a/src/sort/sortJSON.ts
+++ b/src/sort/sortJSON.ts
@@ -1,19 +1,71 @@
+import {parse as parseJSONC, stringify as stringifyJSONC} from 'comment-json';
 import json5 from 'json5';
 import jsonAbc from 'jsonabc';
 import type {SortFunction} from './SortFunction';
 
+type Indexable = {[key: string]: unknown; [key: symbol]: unknown};
+
+/**
+ * Sorts object keys alphabetically, in place and recursively. Array order is
+ * left untouched (matching the previous jsonabc behavior).
+ *
+ * "comment-json" stores comments as symbol-keyed metadata named after the
+ * property they belong to (e.g. `before:abc`), so re-attaching those symbols
+ * after reordering the keys makes each comment travel with its property.
+ */
+function sortDeep(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    value.forEach(sortDeep);
+    return value;
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const node = value as Indexable;
+    const keys = Object.keys(node).sort();
+    const values = new Map<string, unknown>(keys.map(key => [key, node[key]]));
+    const comments = new Map<symbol, unknown>(Object.getOwnPropertySymbols(node).map(symbol => [symbol, node[symbol]]));
+
+    for (const key of keys) {
+      delete node[key];
+    }
+    for (const key of keys) {
+      node[key] = sortDeep(values.get(key));
+    }
+    for (const [symbol, comment] of comments) {
+      node[symbol] = comment;
+    }
+
+    return node;
+  }
+
+  return value;
+}
+
 export const sortJSON: SortFunction = (input: string) => {
   try {
-    const object = json5.parse(input);
-    const sorted = jsonAbc.sortObj(object, true);
+    // "comment-json" parses JSON/JSONC while preserving comments, so sorting
+    // keeps the comments attached to the properties they document.
+    const parsed = parseJSONC(input);
+    sortDeep(parsed);
     return {
-      payload: JSON.stringify(sorted, null, 2),
+      payload: stringifyJSONC(parsed, null, 2),
       type: 'success',
     };
-  } catch (error) {
-    return {
-      error: error as Error,
-      type: 'error',
-    };
+  } catch {
+    // Fall back to JSON5 for inputs comment-json cannot parse (e.g. unquoted
+    // keys or single quotes). Comments are not preserved on this path.
+    try {
+      const object = json5.parse(input);
+      const sorted = jsonAbc.sortObj(object, true);
+      return {
+        payload: JSON.stringify(sorted, null, 2),
+        type: 'success',
+      };
+    } catch (error) {
+      return {
+        error: error as Error,
+        type: 'error',
+      };
+    }
   }
 };

--- a/src/test/fixtures/block-comments.json5
+++ b/src/test/fixtures/block-comments.json5
@@ -1,0 +1,6 @@
+{
+  /* XYZ */
+  "xyz": "xyz",
+  /* ABC */
+  "abc": "abc"
+}

--- a/src/test/fixtures/line-comments.json5
+++ b/src/test/fixtures/line-comments.json5
@@ -1,0 +1,6 @@
+{
+  // XYZ
+  "xyz": "xyz",
+  // ABC
+  "abc": "abc"
+}

--- a/src/test/fixtures/nested-comments.json5
+++ b/src/test/fixtures/nested-comments.json5
@@ -1,0 +1,9 @@
+{
+  // root note
+  "server": {
+    // port to bind
+    "port": 8080,
+    "host": "localhost"
+  },
+  "active": true
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1212,6 +1212,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+array-timsort@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-timsort/-/array-timsort-1.0.3.tgz#3c9e4199e54fb2b9c3fe5976396a21614ef0d926"
+  integrity sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==
+
 babel-jest@30.4.1:
   version "30.4.1"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-30.4.1.tgz#63cba904438bbe64c4cf0acdea87b0a45cb809fc"
@@ -1442,6 +1447,17 @@ commander@^2.20.0:
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+comment-json@4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/comment-json/-/comment-json-4.2.5.tgz#482e085f759c2704b60bc6f97f55b8c01bc41e70"
+  integrity sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==
+  dependencies:
+    array-timsort "^1.0.3"
+    core-util-is "^1.0.3"
+    esprima "^4.0.1"
+    has-own-prop "^2.0.0"
+    repeat-string "^1.6.1"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1452,9 +1468,9 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-core-util-is@~1.0.0:
+core-util-is@^1.0.3, core-util-is@~1.0.0:
   version "1.0.3"
-  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cross-env@^10.1.0:
@@ -1583,7 +1599,7 @@ eslint-scope@5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -1770,6 +1786,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-own-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-own-prop/-/has-own-prop-2.0.0.tgz#f0f95d58f65804f5d218db32563bb85b8e0417af"
+  integrity sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==
 
 hasown@^2.0.2:
   version "2.0.2"
@@ -2733,6 +2754,11 @@ rechoir@^0.8.0:
   integrity sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==
   dependencies:
     resolve "^1.20.0"
+
+repeat-string@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Fixes #12. Supersedes #25 (which can be closed).

## Problem
Sorting a JSON5/JSONC file silently **dropped every comment**. `sortJSON` parsed with `json5` (comment-aware) but then serialized with `JSON.stringify()`, which discards comments entirely.

## Approach
Rather than the regex/string-splicing route in #25 — which only handled comments before *root-level* properties and broke on nesting — this mirrors how the **YAML** sorter already works in this repo: parse into a model that preserves comments, sort the members in place, then serialize.

[`comment-json`](https://www.npmjs.com/package/comment-json) is the purpose-built library for that. It stores comment metadata keyed by property name (e.g. `before:abc`), so re-attaching that metadata after reordering keys makes each comment **travel with the property it documents** — at any nesting depth.

## Behavior
- **Object keys** sorted recursively; **array order untouched** — matches the previous `jsonabc.sortObj(obj, true)` behavior (verified: it never reordered arrays).
- Inputs `comment-json` can't parse (true JSON5 — unquoted keys, single quotes) **fall back** to the original `json5` path, so nothing that sorted before stops sorting (comments still can't be preserved there).

## Tests
New `sortJSON.test.ts` covering line comments, block comments, **nested-object** comments, plain key sorting, and the error path. Full pipeline green: webpack build, `biome check`, `tsc --noEmit`, 10 tests + 4 snapshots.

## Dependency
Adds `comment-json` (runtime). It's the standard tool for comment-preserving JSON manipulation and avoids hand-rolling a fragile CST.